### PR TITLE
Added option g:markology_disable_mappings

### DIFF
--- a/doc/markology.txt
+++ b/doc/markology.txt
@@ -313,6 +313,11 @@ behaves:
              0 - do not wrap
              1 - always wrap (default)
 
+'markology_disable_mappings' boolean (default: 0) *'markology_disable_mappings'*
+                        global
+    This option defines whether mappings should be created by markology. If it
+    is set to 1, key mappings will not be created by markology.
+
 ===============================================================================
 Highlighting                                        *markology-highlighting*
 

--- a/plugin/markology.vim
+++ b/plugin/markology.vim
@@ -82,21 +82,23 @@ nnoremap <silent> <Plug>MarkologyLocationList           :MarkologyLocationList<C
 nnoremap <silent> <Plug>MarkologyQuickFix               :MarkologyQuickFix<CR>
 
 " Set Default Mappings (NOTE: Leave the '|'s immediately following the '<cr>' so the mapping does not contain any trailing spaces!)
-if !hasmapto( '<Plug>MarkologyEnable' )               |  map <silent> <leader>m1 :MarkologyEnable<cr>               |  endif
-if !hasmapto( '<Plug>MarkologyDisable' )              |  map <silent> <leader>m0 :MarkologyDisable<cr>              |  endif
-if !hasmapto( '<Plug>MarkologyToggle' )               |  map <silent> <leader>m! :MarkologyToggle<cr>               |  endif
-if !hasmapto( '<Plug>MarkologyPlaceMarkToggle' )      |  map <silent> <leader>m, :MarkologyPlaceMarkToggle<cr>      |  endif
-if !hasmapto( '<Plug>MarkologyPlaceMark' )            |  map <silent> <leader>m+ :MarkologyPlaceMark<cr>            |  endif
-if !hasmapto( '<Plug>MarkologyClearMark' )            |  map <silent> <leader>m- :MarkologyClearMark<cr>            |  endif
-if !hasmapto( '<Plug>MarkologyClearAll' )             |  map <silent> <leader>m_ :MarkologyClearAll<cr>             |  endif
-if !hasmapto( '<Plug>MarkologyNextLocalMarkPos' )     |  map <silent> <leader>m] :MarkologyNextLocalMarkPos<cr>     |  endif
-if !hasmapto( '<Plug>MarkologyPrevLocalMarkPos' )     |  map <silent> <leader>m[ :MarkologyPrevLocalMarkPos<cr>     |  endif
-if !hasmapto( '<Plug>MarkologyNextLocalMarkByAlpha' ) |  map <silent> <leader>m{ :MarkologyNextLocalMarkByAlpha<cr> |  endif
-if !hasmapto( '<Plug>MarkologyPrevLocalMarkByAlpha' ) |  map <silent> <leader>m} :MarkologyPrevLocalMarkByAlpha<cr> |  endif
-if !hasmapto( '<Plug>MarkologyLocationList' )         |  map <silent> <leader>m? :MarkologyLocationList<cr>         |  endif
-if !hasmapto( '<Plug>MarkologyQuickFix' )             |  map <silent> <leader>m^ :MarkologyQuickFix<cr>             |  endif
-noremap <script> \sm m
-noremap <silent> m :exe 'norm \sm'.nr2char(getchar())<bar>call <sid>Markology()<CR>
+if !exists("g:markology_disable_mappings") || !g:markology_disable_mappings
+    if !hasmapto( '<Plug>MarkologyEnable' )               |  map <silent> <leader>m1 :MarkologyEnable<cr>               |  endif
+    if !hasmapto( '<Plug>MarkologyDisable' )              |  map <silent> <leader>m0 :MarkologyDisable<cr>              |  endif
+    if !hasmapto( '<Plug>MarkologyToggle' )               |  map <silent> <leader>m! :MarkologyToggle<cr>               |  endif
+    if !hasmapto( '<Plug>MarkologyPlaceMarkToggle' )      |  map <silent> <leader>m, :MarkologyPlaceMarkToggle<cr>      |  endif
+    if !hasmapto( '<Plug>MarkologyPlaceMark' )            |  map <silent> <leader>m+ :MarkologyPlaceMark<cr>            |  endif
+    if !hasmapto( '<Plug>MarkologyClearMark' )            |  map <silent> <leader>m- :MarkologyClearMark<cr>            |  endif
+    if !hasmapto( '<Plug>MarkologyClearAll' )             |  map <silent> <leader>m_ :MarkologyClearAll<cr>             |  endif
+    if !hasmapto( '<Plug>MarkologyNextLocalMarkPos' )     |  map <silent> <leader>m] :MarkologyNextLocalMarkPos<cr>     |  endif
+    if !hasmapto( '<Plug>MarkologyPrevLocalMarkPos' )     |  map <silent> <leader>m[ :MarkologyPrevLocalMarkPos<cr>     |  endif
+    if !hasmapto( '<Plug>MarkologyNextLocalMarkByAlpha' ) |  map <silent> <leader>m{ :MarkologyNextLocalMarkByAlpha<cr> |  endif
+    if !hasmapto( '<Plug>MarkologyPrevLocalMarkByAlpha' ) |  map <silent> <leader>m} :MarkologyPrevLocalMarkByAlpha<cr> |  endif
+    if !hasmapto( '<Plug>MarkologyLocationList' )         |  map <silent> <leader>m? :MarkologyLocationList<cr>         |  endif
+    if !hasmapto( '<Plug>MarkologyQuickFix' )             |  map <silent> <leader>m^ :MarkologyQuickFix<cr>             |  endif
+    noremap <script> \sm m
+    noremap <silent> m :exe 'norm \sm'.nr2char(getchar())<bar>call <sid>Markology()<CR>
+endif
 
 " AutoCommands: Only if Markology is enabled
 if g:markology_enable == 1


### PR DESCRIPTION
This is a really nice little plugin. I've been using it so that I can get better at using marks. However, I find it annoying when plugins create default keybindings. I rarely use the defaults, and don't want to go to the trouble of exhaustively remapping everything just so I can get my precious `<leader>m` back.

This patch lets me disable the defaults by doing a simple 

``` viml
let g:markology_disable_mappings = 1
```
