### PR TITLE
use noremap instead of map to avoid space mapping issue

### DIFF
--- a/plugin/markology.vim
+++ b/plugin/markology.vim
@@ -83,19 +83,19 @@ nnoremap <silent> <Plug>MarkologyQuickFix               :MarkologyQuickFix<CR>
 
 " Set Default Mappings (NOTE: Leave the '|'s immediately following the '<cr>' so the mapping does not contain any trailing spaces!)
 if !exists("g:markology_disable_mappings") || !g:markology_disable_mappings
-    if !hasmapto( '<Plug>MarkologyEnable' )               |  map <silent> <leader>m1 :MarkologyEnable<cr>               |  endif
-    if !hasmapto( '<Plug>MarkologyDisable' )              |  map <silent> <leader>m0 :MarkologyDisable<cr>              |  endif
-    if !hasmapto( '<Plug>MarkologyToggle' )               |  map <silent> <leader>m! :MarkologyToggle<cr>               |  endif
-    if !hasmapto( '<Plug>MarkologyPlaceMarkToggle' )      |  map <silent> <leader>m, :MarkologyPlaceMarkToggle<cr>      |  endif
-    if !hasmapto( '<Plug>MarkologyPlaceMark' )            |  map <silent> <leader>m+ :MarkologyPlaceMark<cr>            |  endif
-    if !hasmapto( '<Plug>MarkologyClearMark' )            |  map <silent> <leader>m- :MarkologyClearMark<cr>            |  endif
-    if !hasmapto( '<Plug>MarkologyClearAll' )             |  map <silent> <leader>m_ :MarkologyClearAll<cr>             |  endif
-    if !hasmapto( '<Plug>MarkologyNextLocalMarkPos' )     |  map <silent> <leader>m] :MarkologyNextLocalMarkPos<cr>     |  endif
-    if !hasmapto( '<Plug>MarkologyPrevLocalMarkPos' )     |  map <silent> <leader>m[ :MarkologyPrevLocalMarkPos<cr>     |  endif
-    if !hasmapto( '<Plug>MarkologyNextLocalMarkByAlpha' ) |  map <silent> <leader>m{ :MarkologyNextLocalMarkByAlpha<cr> |  endif
-    if !hasmapto( '<Plug>MarkologyPrevLocalMarkByAlpha' ) |  map <silent> <leader>m} :MarkologyPrevLocalMarkByAlpha<cr> |  endif
-    if !hasmapto( '<Plug>MarkologyLocationList' )         |  map <silent> <leader>m? :MarkologyLocationList<cr>         |  endif
-    if !hasmapto( '<Plug>MarkologyQuickFix' )             |  map <silent> <leader>m^ :MarkologyQuickFix<cr>             |  endif
+    if !hasmapto( '<Plug>MarkologyEnable' )               |  noremap <silent> <leader>m1 :MarkologyEnable<cr>               |  endif
+    if !hasmapto( '<Plug>MarkologyDisable' )              |  noremap <silent> <leader>m0 :MarkologyDisable<cr>              |  endif
+    if !hasmapto( '<Plug>MarkologyToggle' )               |  noremap <silent> <leader>m! :MarkologyToggle<cr>               |  endif
+    if !hasmapto( '<Plug>MarkologyPlaceMarkToggle' )      |  noremap <silent> <leader>m, :MarkologyPlaceMarkToggle<cr>      |  endif
+    if !hasmapto( '<Plug>MarkologyPlaceMark' )            |  noremap <silent> <leader>m+ :MarkologyPlaceMark<cr>            |  endif
+    if !hasmapto( '<Plug>MarkologyClearMark' )            |  noremap <silent> <leader>m- :MarkologyClearMark<cr>            |  endif
+    if !hasmapto( '<Plug>MarkologyClearAll' )             |  noremap <silent> <leader>m_ :MarkologyClearAll<cr>             |  endif
+    if !hasmapto( '<Plug>MarkologyNextLocalMarkPos' )     |  noremap <silent> <leader>m] :MarkologyNextLocalMarkPos<cr>     |  endif
+    if !hasmapto( '<Plug>MarkologyPrevLocalMarkPos' )     |  noremap <silent> <leader>m[ :MarkologyPrevLocalMarkPos<cr>     |  endif
+    if !hasmapto( '<Plug>MarkologyNextLocalMarkByAlpha' ) |  noremap <silent> <leader>m{ :MarkologyNextLocalMarkByAlpha<cr> |  endif
+    if !hasmapto( '<Plug>MarkologyPrevLocalMarkByAlpha' ) |  noremap <silent> <leader>m} :MarkologyPrevLocalMarkByAlpha<cr> |  endif
+    if !hasmapto( '<Plug>MarkologyLocationList' )         |  noremap <silent> <leader>m? :MarkologyLocationList<cr>         |  endif
+    if !hasmapto( '<Plug>MarkologyQuickFix' )             |  noremap <silent> <leader>m^ :MarkologyQuickFix<cr>             |  endif
     noremap <script> \sm m
     noremap <silent> m :exe 'norm \sm'.nr2char(getchar())<bar>call <sid>Markology()<CR>
 endif


### PR DESCRIPTION
A simple pull request, the request is to use noremap instead of map.
The issue stems from the fact that I mapped `<space>` to `:` so by using noremap the rhs of mapping does not get expanded, while right now, using map, I end up typing on vim's commandline area after using one of the mappings.
The rhs is actually mapped to `,m0         * :MarkologyDisable<CR>             <Space>` (taken from `:verb map ,m0`) so another solution to this issue would be to put the pipe right after `<cr>` but it would be less pretty in the source code (using `noremap` is ok since it's a mapping to a command).
