### PR TITLE
Fix bug with lowercase mark & highlight group

### DIFF
--- a/autoload/markology.vim
+++ b/autoload/markology.vim
@@ -198,8 +198,6 @@ fun! s:MarkologySetup()
             if g:markology_hlline_lower
                 " let lhltext = 'linehl='.s:MarkologyDLink{nm}.nm
                 let lhltext = 'linehl=MarkologyHLLine'
-            else
-                let lhltext = 'linehl=Normal'
             endif
         elseif c =~# '[A-Z]'
             if strlen(g:markology_textupper) == 1


### PR DESCRIPTION
When setting marks with a lowercase letter, line highlighting is lost. This change
mirrors the logic for uppercase letter marks

Example:

![image](https://user-images.githubusercontent.com/191564/63141248-12626400-bfb3-11e9-9cc6-113531b31939.png)

Closes jeetsukumaran/vim-markology/#14

Tested on neovim 0.3.8 & 0.4.0-dev (macOS)